### PR TITLE
Update DHSC and OHID HTML page layout to make the body wider

### DIFF
--- a/_extensions/DHSC/_extension.yml
+++ b/_extensions/DHSC/_extension.yml
@@ -1,6 +1,6 @@
 title: DHSC
 author: Olivia Box Power
-version: 1.0.2
+version: 1.0.3
 quarto-required: ">=1.2.0"
 contributes:
   formats:
@@ -11,6 +11,7 @@ contributes:
       toc_float: true
       toc_depth: 3
       toc-location: left
+      page-layout: full
       include-before-body: "stylesheets/DHSC_logo.html"
       theme:
         - default

--- a/_extensions/OHID/_extension.yml
+++ b/_extensions/OHID/_extension.yml
@@ -1,6 +1,6 @@
 title: OHID
 author: Olivia Box Power
-version: 1.0.2
+version: 1.0.3
 quarto-required: ">=1.2.0"
 contributes:
   formats:
@@ -11,6 +11,7 @@ contributes:
       toc_float: true
       toc_depth: 3
       toc-location: left
+      page-layout: full
       include-before-body: "stylesheets/OHID_logo.html"
       theme:
         - default


### PR DESCRIPTION
See this page in the [quarto docs](https://quarto.org/docs/output-formats/page-layout.html#more-examples). I think using the full page layout should work. With full page layout it uses the right side margin space if it can.

The GOVUK HTML template already sets the max size of each column in the layout, but I'm not sure that's actually necessary for the DHSC/OHID HTML template.
```
      grid:
        sidebar-width: 200px
        gutter-width: 1em
        margin-width: 100px
        body-width: 900px
```

